### PR TITLE
Stickers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "lucid-creations-media-potty-chart",
   "homepage": "https://lucidcreations.media/introducing-code-name-potty-chart/",
-  "version": "v0.0.7.0-alpha",
+  "version": "v0.0.7.3-alpha",
   "author": {
     "name": "Lucid Creations Media",
     "url": "https://lucidcreations.media",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,7 +5,7 @@ import AppTheme from "../theme/AppTheme";
 
 const description =
   // "Behavior and progress tracker for ABDLs and babyfurs alike. Track multiple littles and create any trackers you would like.";
-  "Pre-alpha preview of the behavior and progress tracker for ABDLs and babyfurs.";
+  "Alpha preview of a, calender like, 'start chart' behavior and progress tracker for ABDLs and babyfurs.";
 
 const logo = "images/logo.svg";
 const logoOG = "/images/logo.png";

--- a/theme/layout/Header.tsx
+++ b/theme/layout/Header.tsx
@@ -15,7 +15,7 @@ import appLogo from "../../public/images/logo.svg";
 
 const Header = (): JSX.Element => {
   const appName = "LCM Potty Chart";
-  const appVersion = "v0.0.7.0-alpha";
+  const appVersion = "v0.0.7.3-alpha";
 
   // Add transparency while not at the top of the page.
   const [transparentNavbar, setTransparentNavbar] = useState<boolean>(false);


### PR DESCRIPTION
Rollback due to a module throwing a lot of errors.

> A module is throwing a lot of errors within the console when the app is in development mode. Attempting to roll back. Upgrade modules 1 by 1 until the offender is identified, then lock it to the last stable version until the bug is fixed on their end.